### PR TITLE
Added recommended products to profile

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -356,6 +356,15 @@ class ProfileProductSerializer(serializers.ModelSerializer):
 
 class RecommenderSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendations"""
+    customer = CustomerSerializer()
+    product = ProfileProductSerializer()
+
+    class Meta:
+        model = Recommendation
+        fields = ('product', 'customer',)
+
+class RecommendedSerializer(serializers.ModelSerializer):
+    """JSON serializer for recommendations"""
     recommender = CustomerSerializer()
     product = ProfileProductSerializer()
 
@@ -372,7 +381,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     """
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
-    recommended = RecommenderSerializer(many=True)
+    recommended = RecommendedSerializer(many=True)
 
     class Meta:
         model = Customer


### PR DESCRIPTION
The get profile request was returning recommendations that the current user made but not recommendations made to the current customer. This addresses that issue by adding a recommends section (for recommendations made by user) and a recommended section (for recommendations made to the user.)

## Changes

Changed the bangazon/views/profile.py to include another serializer for recommended products (to the auth-user) as well as recommends products (from the auth-user)

To Test:
1. Pull branch tlc-recommends
2. From postman, request profile.
3. Check that a recommends array is returned that includes a project and a customer.
  ----- If an empty array is returned, confirm that there are entries in recommendations database with the current user as the recommender.
4. Confirm that the customer is not the current user but instead the customer to whom the current user made the recommendation.
5. Check that a recommended array is returned that includes a project and a customer.
 ------ If an empty array is returned, confirm that there are entries in recommendations database with the current user as the customer.
6. Confirm that the recommender is not the current user but instead the customer that made the recommendation to the current customer.
7.  Check out the code and make sure if doesn't look crazy.

