### PR TITLE
PaymentType filtered by Logged in user.

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,13 +79,10 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+
 
         customer = Customer.objects.get(user=request.auth.user)
-
-        # customer = self.request.query_params.get('customer', None)
-        if customer is not None:
-            payment_types = payment_types.filter(customer_id=customer)
+        payment_types = Payment.objects.filter(customer=customer)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,11 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        # customer = self.request.query_params.get('customer', None)
+        if customer is not None:
+            payment_types = payment_types.filter(customer_id=customer)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Change to paymenttype.py list function to filter by auth_user

Changes:

When a client requests the paymenttypes, all paymenttypes were returned. This fix address that issue by filtering payment types according to the user that's logged in. 

Steps to test:
Git fetch --all
Pull branch tlc-paymenttype-filter
From the command line, run ./seed_data.sh
start the server python3 manage.py runserver
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146694
From Postman, request profile . http://localhost:8000/paymenttypes
Confirm that only one payment type is returned and it has an id of 1 and merchant_name of visa.
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c14669c
From Postman, request profile . http://localhost:8000/paymenttypes
Confirm that payment type returned has an id of 3 and merchant_name of visa.
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146690
From Postman, request profile . http://localhost:8000/paymenttypes
Confirm that any empty array is returned.
Check the code differences and see if anything looks crazy.

Related Issues
Fixes Bug: #18 