### PR TITLE
Tlc paymenttype date

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,13 +79,10 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+
 
         customer = Customer.objects.get(user=request.auth.user)
-
-        # customer = self.request.query_params.get('customer', None)
-        if customer is not None:
-            payment_types = payment_types.filter(customer_id=customer)
+        payment_types = Payment.objects.filter(customer=customer)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,11 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        # customer = self.request.query_params.get('customer', None)
+        if customer is not None:
+            payment_types = payment_types.filter(customer_id=customer)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Change to paymenttype.py create function to correct created date and expiration date.

Changes:

When a client created a new payment type, the create date and expiration dates were switched. This fix remedies that. 

Steps to test:
Git fetch --all
Pull branch tlc-paymenttype-date
From the command line, run ./seed_data.sh
start the server python3 manage.py runserver
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146690
From Postman, request payment type . http://localhost:8000/paymenttypes
Confirm that any empty array is returned.
Now change to that a post to request to 
paste this in the body:
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
Send the request. 
Confirm you receive the added payment time in the response.  
Confirm that the expiration and create dates are correct.
From Postman, request payment type . http://localhost:8000/paymenttypes
Confirm that the newly created object is returned.
Check the code differences and see if anything looks crazy.

Related Issues
Fixes Bug: #19 