### PR TITLE
Products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -246,6 +246,7 @@ class Products(ViewSet):
 
         # Support filtering by category and/or quantity
         category = self.request.query_params.get('category', None)
+        location = self.request.query_params.get('location', None)
         quantity = self.request.query_params.get('quantity', None)
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
@@ -273,6 +274,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+        
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Change to views/product.py create to enable the user to filter by location.

Changes:

When a clients viewing products, they may want to filter by location. This enhancement will enable them to do so.

Steps to test:
Git fetch --all
Pull branch tlc-prod-location
From the command line, run ./seed_data.sh
start the server python3 manage.py runserver
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146690
From Postman, request a product my location name, or part of location name. Here is an example, which can be used.
http://localhost:8000/products?location=Górki
Confirm that all products at with that location are returned. In the above case, the product with id of 3 and name of Durango should be return.
Check the code differences and see if anything looks crazy.

Related Issues
Adds Feature: #14