### PR TITLE
Min products sold.

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -269,7 +269,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Change to views/product.py to set a min number_sold filter through the url

Changes:

When a client requests products with a minimum number_sold using the url, the response was incorrectly returning all products with that number of sales or less rather than that number or greater. 

Made changes to the views/product.py file.

Steps to test:
Git fetch --all
Pull branch tlc-min-products
From the command line, run ./seed_data.sh
start the server python3 manage.py runserver
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146694
From Postman, request products that have sold at least once but putting in. http://localhost:8000/products?number_sold=1
Confirm that two products are returned, one with a number_sold of 1 and a with number_sold of 2.
In Postman, change that number to 2 --- http://localhost:8000/products?number_sold=2
Confirm that only one product is returned with a number_sold of 2.
Check the code differences and see if anything looks crazy.

Related Issues
Fixes Bug: #21 