### PR TITLE
remove item working

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Change to views/lineitem.py to enable users to delete an item from the cart.

Changes:

Users cannot delete items from their car. This fix should enable them to do so. 

Steps to test:

Git fetch --all
Pull branch tlc-remove-item
From the command line, run ./seed_data.sh
start the server python3 manage.py runserver
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146694

From Postman, request (get) line item 6.  http://localhost:8000/lineitems/6
Confirm that line item with id of 6 is return. 

In Postman, send a delete request for line item 6. http://localhost:8000/lineitems/6
Confirm than an empty object is returned.

In Postman, get line item 6 again. http://localhost:8000/lineitems/6
Confirm that a 404 Not found error is returned with a message "message": "OrderProduct matching query does not exist."

Check the code differences and see if anything looks crazy.
Related Issues
Fixes Bug: 20
