### PR TITLE
Add Favorite

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,5 +1,6 @@
 """View module for handling requests about customer profiles"""
 import datetime
+import re
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
 from rest_framework import serializers, status
@@ -12,6 +13,7 @@ from bangazonapi.models import OrderProduct, Favorite
 from bangazonapi.models import Recommendation
 from .product import ProductSerializer
 from .order import OrderSerializer
+# from .lineitem import LineItemSerializer
 
 
 class Profile(ViewSet):
@@ -255,7 +257,7 @@ class Profile(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get', 'post'], detail=False)
     def favoritesellers(self, request):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
@@ -282,33 +284,30 @@ class Profile(ViewSet):
                         "address": "100 Endless Way",
                         "user": "http://localhost:8000/users/6"
                     }
-                },
-                {
-                    "id": 2,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/6",
-                        "phone_number": "555-1212",
-                        "address": "100 Dauntless Way",
-                        "user": "http://localhost:8000/users/7"
-                    }
-                },
-                {
-                    "id": 3,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/7",
-                        "phone_number": "555-1212",
-                        "address": "100 Indefatiguable Way",
-                        "user": "http://localhost:8000/users/8"
-                    }
                 }
-            ]
         """
-        customer = Customer.objects.get(user=request.auth.user)
-        favorites = Favorite.objects.filter(customer=customer)
+        if request.method == "GET":
+            
+            customer = Customer.objects.get(user=request.auth.user)
+            favorites = Favorite.objects.filter(customer=customer)
 
-        serializer = FavoriteSerializer(
+            serializer = FavoriteSerializer(
             favorites, many=True, context={'request': request})
-        return Response(serializer.data)
+            return Response(serializer.data)
+
+        if request.method == "POST":
+            
+            new_favorite = Favorite()
+            customer = Customer.objects.get(user=request.auth.user)
+            new_favorite.customer = customer
+            new_favorite.seller = Customer.objects.get(pk=request.data["seller_id"])
+
+            new_favorite.save()
+
+            serializer = FavoriteSerializer(
+            new_favorite, many=False, context={'request': request})
+            return Response(serializer.data)
+
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
Change to views/provide.py to enable users to favorite specific sellers 

Changes:
Made changes to @action favoritesellers on the views/product.py file.

Steps to test:

Git fetch --all
Pull branch tlc-favorite-seller
From the command line, run ./seed_data.sh
start the server python3 manage.py runserver
In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c146694
Send the following GET request in Postman. http://localhost:8000/profile/favoritesellers
Confirm that you get a few sellers returned. 
Put the following POST request to Postman with the body below:
{
   "seller_id": 6
}

Confirm that you get the information for customer 6 returned (David Jisie)
Make a GET request again for all favorite sellers and make sure David Jisie is on the list. 
Check the code differences and see if anything looks crazy.

Related Issues
Adds Feature: 13
