### PR TITLE
Fixes bug to enable products to be added to a new order

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -112,11 +112,11 @@ class Cart(ViewSet):
             open_order = Order.objects.get(
                 customer=current_user, payment_type=None)
 
-            # products_on_order = Product.objects.filter(
-            #     lineitems__order=open_order)
+            products_on_order = Product.objects.filter(
+                lineitems__order=open_order)
 
-            # serialized_order = OrderSerializer(
-            #     open_order, many=False, context={'request': request})
+            serialized_order = OrderSerializer(
+                open_order, many=False, context={'request': request})
 
             product_list = ProductSerializer(
                 products_on_order, many=True, context={'request': request})

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -106,8 +106,7 @@ class Orders(ViewSet):
         order = Order.objects.get(pk=pk, customer=customer)
         order_payment = Payment.objects.get(pk=request.data["payment_type_id"])
         order.payment_type = order_payment
-        # order_products = Product.objects.get(pk=request.data['product_id'])
-        # order.products = order_products
+
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,10 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order_payment = Payment.objects.get(pk=request.data["payment_type_id"])
+        order.payment_type = order_payment
+        # order_products = Product.objects.get(pk=request.data['product_id'])
+        # order.products = order_products
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -234,7 +234,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Fixed bug that prevented users from adding products to a new cart/order

Changes:
Made changes to @action cart on the views/product.py file.

Steps to test:

Git fetch --all

Pull branch tlc-prod-last-order

From the command line, run ./seed_data.sh

start the server python3 manage.py runserver

In Postman, paste this key into the Authorization header. Token 9ba45f09651c5b0c404f37a2d2572c026c14669c

In Postman, add a payment type using a Post Request to http://localhost:8000/paymenttypes
{
    "merchant_name": "Mastercard",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}

In Postman, Sent a Post Request to the cart: http://localhost:8000/profile/cart
{
    "product_id": 4
}

Check the cart to make sure the product was added http://localhost:8000/profile/cart
Note the order id number. 
Complete the order by adding your payment type. To do this, sent a put request in postman with a payment_type_id field with the payment__type id from the payment type you created.  
http://localhost:8000/orders/(theordernumber)
{
    "id": order id number,
    "url": "http://localhost:8000/orders/order id number",
    "created_date": "2021-09-03",
    "payment_type_id": payment id,
    "customer": "http://localhost:8000/customers/7"
}

Confirm that an empty object is returned.

Get the order to confirm that a payment type has been added. Send the following GET request in Postman. http://localhost:8000/orders/(your order number)

Post a new item to the cart. http://localhost:8000/profile/cart

Confirm that it is the only item in the cart by sending a get request to http://localhost:8000/profile/cart

Check the code differences and see if anything looks crazy.


Related Issues
Fixes Bug: 23 
