### PR TITLE
changed max price

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)


### PR DESCRIPTION
Increased the max price of a product from $10,000 to $17,500.

## Changes

- Changed the max price validator in the product model from $10,000.00 to $17,500.00. Note this is only a change for that Validator. Neither figure is limiting the price currently of new products, as detailed in a separate ticket. 

## Requests / Responses

Changed the following code in the models/product.py

   price = models.FloatField(
        validators=[MinValueValidator(0.00), **MaxValueValidator(17500.00)]**,)


## Testing

There is no real test here because the validator is not working for either amount, as detailed in a separate ticket. But the limit was changed in the code.  The changes need to be confirmed in the comparison of the code. 


## Related Issues

- Fixes #16
