### PR TITLE
Test to delete payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -56,8 +56,12 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+            
+        except Payment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
-            return HttpResponseServerError(ex)
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single payment type

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -6,7 +6,7 @@ from bangazonapi.models import Payment, customer
 
 
 class PaymentTests(APITestCase):
-    def setUp(self) -> None:
+    def setUp(self):
         """
         Create a new account and create sample category
         """
@@ -17,6 +17,18 @@ class PaymentTests(APITestCase):
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        payment = Payment()
+        payment.merchant_name = "Mastercard"
+        payment.account_number = "211-1111-1111"
+        payment.expiration_date = "2025-12-31"
+        payment.create_date = str(datetime.date.today())
+        payment.customer_id = 1
+
+        payment.save()
+
+
 
 
     def test_create_payment_type(self):
@@ -31,7 +43,7 @@ class PaymentTests(APITestCase):
             "expiration_date": "2024-12-31",
             "create_date": datetime.date.today()
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        
         response = self.client.post(url, data, format='json')
         json_response = json.loads(response.content)
 
@@ -45,23 +57,14 @@ class PaymentTests(APITestCase):
 
     def test_delete_payment_type(self):
         """Make sure we can remove payment types"""
-        #I am getting a 500 error message rather than 404 and not sure why.
+   
+        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
-        payment = Payment()
-        payment.merchant_name = "American Express"
-        payment.account_number = "111-1111-1111"
-        payment.expiration_date = "2024-12-31"
-        payment.create_date = str(datetime.date.today())
-        payment.customer_id = 1
-
-        payment.save()
-
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.delete(f"/paymenttypes/{payment.id}")
+        response = self.client.delete(f"/paymenttypes/1")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        # GET GAME AGAIN TO VERIFY 404 response
-        response = self.client.get(f"/paymenttypes/{payment.id}")
+        # GET PAYMENT AGAIN TO VERIFY 404 response
+        response = self.client.get(f"/paymenttypes/1")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -45,12 +45,14 @@ class PaymentTests(APITestCase):
 
     def test_delete_payment_type(self):
         """Make sure we can remove payment types"""
+        #I am getting a 500 error message rather than 404 and not sure why.
 
         payment = Payment()
         payment.merchant_name = "American Express"
         payment.account_number = "111-1111-1111"
         payment.expiration_date = "2024-12-31"
         payment.create_date = str(datetime.date.today())
+        payment.customer_id = 1
 
         payment.save()
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -57,8 +57,6 @@ class PaymentTests(APITestCase):
 
     def test_delete_payment_type(self):
         """Make sure we can remove payment types"""
-   
-        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
         response = self.client.delete(f"/paymenttypes/1")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import Payment, customer
 
 
 class PaymentTests(APITestCase):
@@ -41,3 +42,24 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+
+    def test_delete_payment_type(self):
+        """Make sure we can remove payment types"""
+
+        payment = Payment()
+        payment.merchant_name = "American Express"
+        payment.account_number = "111-1111-1111"
+        payment.expiration_date = "2024-12-31"
+        payment.create_date = str(datetime.date.today())
+
+        payment.save()
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(f"/paymenttypes/{payment.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # GET GAME AGAIN TO VERIFY 404 response
+        response = self.client.get(f"/paymenttypes/{payment.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+


### PR DESCRIPTION
This tests the delete payment functionality.

Changes:
Made changes to the test_delete_payment_type in the tests/payments.py file.  Added that 

Git fetch --all
Pull branch tlc-delete_paymenttypes
Run all tests with the python3 manage.py test tests -v 1 command. 
There will be errors on two of seven tests. Confirm that test_delete_payment_type is not one of the tests with errors.

Issue:
# 9 test delete payment